### PR TITLE
os independent pathname splitting

### DIFF
--- a/flask_resize/__init__.py
+++ b/flask_resize/__init__.py
@@ -351,13 +351,13 @@ def generate_image(inpath, outpath, width=None, height=None, format=JPEG,
             DeprecationWarning
         )
 
-    _mkdir_p(outpath.rpartition('/')[0])
+    _mkdir_p(os.path.split(outpath)[0])
     if not os.path.isfile(inpath):
         if placeholder_reason:
             img = create_placeholder_img(width, height, placeholder_reason)
         else:
             raise exc.ImageNotFoundError(inpath)
-    elif inpath.rpartition('.')[2].upper() == SVG:
+    elif os.path.splitext(inpath)[1][1:].upper() == SVG:
         img = convert_svg(inpath)
     else:
         img = Image.open(inpath)


### PR DESCRIPTION
I ran into an issue when testing on Windows. As in Windows for path separation `\\` is used `rpartition('/')` won' t do its work here. Instead I used the fitting os.path functions for making it work on Windows and Linux.
