### PR TITLE
2.0

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+known_first_party=
+    flask_resize
+line_length=79
+multi_line_output=3
+not_skip=__init__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,46 +8,65 @@ services:
 matrix:
   include:
   - python: 2.7
-    env: TOX_ENV=py-release
+    env: TOXENV=py-release
   - python: 2.7
-    env: TOX_ENV=py-full
+    env: TOXENV=py-full
   - python: 2.7
-    env: TOX_ENV=py-redis
+    env: TOXENV=py-redis
   - python: 2.7
-    env: TOX_ENV=py-s3
+    env: TOXENV=py-s3
   - python: 3.3
-    env: TOX_ENV=py-release
+    env: TOXENV=py-release
   - python: 3.3
-    env: TOX_ENV=py-full
+    env: TOXENV=py-full
   - python: 3.3
-    env: TOX_ENV=py-redis
+    env: TOXENV=py-redis
   - python: 3.3
-    env: TOX_ENV=py-s3
+    env: TOXENV=py-s3
   - python: 3.4
-    env: TOX_ENV=py-release
+    env: TOXENV=py-release
   - python: 3.4
-    env: TOX_ENV=py-full
+    env: TOXENV=py-full
   - python: 3.4
-    env: TOX_ENV=py-redis
+    env: TOXENV=py-redis
   - python: 3.4
-    env: TOX_ENV=py-s3
+    env: TOXENV=py-s3
   - python: 3.4
-    env: TOX_ENV=py-svg
+    env: TOXENV=py-svg
   - python: 3.5
-    env: TOX_ENV=py-release
+    env: TOXENV=py-release
   - python: 3.5
-    env: TOX_ENV=py-full
+    env: TOXENV=py-full
   - python: 3.5
-    env: TOX_ENV=py-redis
+    env: TOXENV=py-redis
   - python: 3.5
-    env: TOX_ENV=py-s3
+    env: TOXENV=py-s3
   - python: 3.5
-    env: TOX_ENV=py-svg
+    env: TOXENV=py-svg
+  - python: 3.6
+    env: TOXENV=py-release
+  - python: 3.6
+    env: TOXENV=py-full
+  - python: 3.6
+    env: TOXENV=py-redis
+  - python: 3.6
+    env: TOXENV=py-s3
+  - python: 3.6
+    env: TOXENV=py-svg
+  - python: pypy
+    env: TOXENV=py-release
+  - python: pypy
+    env: TOXENV=py-full
+  - python: pypy
+    env: TOXENV=py-redis
+  - python: pypy
+    env: TOXENV=py-s3
+
 install:
     - pip install tox
 
 script:
-    - tox -e $TOX_ENV
+    - tox
 
 after_success:
     - pip install coveralls

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## About
 
-Flask extension for automating the resizing of images in your code and templates. Can convert to JPEG|PNG from JPEG|PNG|SVG, resize to fit and crop. File-based and S3-based storage options are available.
+Flask extension for automating the resizing of images in your code and templates. Can convert from JPEG|PNG|SVG to JPEG|PNG, resize to fit and crop. File-based and S3-based storage options are available.
 
 Created by [Jacob Magnusson](https://twitter.com/jacobsvante_).
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,49 @@
+# Made with help from https://packaging.python.org/appveyor/
+
+environment:
+  TOX_TESTENV_PASSENV: DISTUTILS_USE_SDK MSSdk INCLUDE LIB
+
+  matrix:
+    - PYTHON: "C:\\Python27"
+      TOXENV: py-release
+    - PYTHON: "C:\\Python27"
+      TOXENV: py-redis
+    - PYTHON: "C:\\Python27"
+      TOXENV: py-s3
+    - PYTHON: "C:\\Python33"
+      TOXENV: py-release
+    - PYTHON: "C:\\Python33"
+      TOXENV: py-redis
+    - PYTHON: "C:\\Python33"
+      TOXENV: py-s3
+    - PYTHON: "C:\\Python34"
+      TOXENV: py-release
+    - PYTHON: "C:\\Python34"
+      TOXENV: py-redis
+    - PYTHON: "C:\\Python34"
+      TOXENV: py-s3
+    - PYTHON: "C:\\Python35"
+      TOXENV: py-release
+    - PYTHON: "C:\\Python35"
+      TOXENV: py-redis
+    - PYTHON: "C:\\Python35"
+      TOXENV: py-s3
+    - PYTHON: "C:\\Python36"
+      TOXENV: py-release
+    - PYTHON: "C:\\Python36"
+      TOXENV: py-redis
+    - PYTHON: "C:\\Python36"
+      TOXENV: py-s3
+
+install:
+  # Install Redis
+  - nuget install redis-64 -excludeversion
+  - redis-64\tools\redis-server.exe --service-install
+  - redis-64\tools\redis-server.exe --service-start
+  # Install tox for testing
+  - "%PYTHON%\\Scripts\\pip install tox"
+
+build: off
+
+test_script:
+  - "%PYTHON%\\Scripts\\tox"

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,12 @@
 import logging
 import os
-import subprocess
+import uuid
 
 import pytest
 from PIL import Image
 
 import flask_resize
+from flask_resize import _compat, resizing
 
 
 logging.basicConfig(format='%(levelname)s:%(name)s:%(thread)d:%(message)s')
@@ -13,10 +14,12 @@ log_level = os.environ.get('RESIZE_LOG_LEVEL', 'error')
 flask_resize.logger.setLevel(getattr(logging, log_level.upper()))
 
 
-@pytest.yield_fixture
-def inspect_filetarget_directory(filetarget):
-    yield
-    subprocess.run(['open', filetarget.image_store.base_path])
+def pytest_addoption(parser):
+    parser.addoption(
+        '--skip-slow',
+        action='store_true',
+        help='Skip slow-running tests',
+    )
 
 
 @pytest.fixture
@@ -26,7 +29,19 @@ def image1():
 
 @pytest.fixture
 def image1_data(image1):
-    return flask_resize.resizing.image_data(image1, 'PNG')
+    return resizing.image_data(image1, 'PNG')
+
+
+@pytest.fixture
+def image1_name():
+    return 'flask-resize-test-{}.png'.format(uuid.uuid4().hex)
+
+
+@pytest.fixture
+def image1_key(image1_name, resizetarget_opts):
+    target = resizing.ResizeTarget(**resizetarget_opts)
+    # Obviously only the key if no processing settings have been pas
+    return target.unique_key
 
 
 @pytest.fixture
@@ -36,7 +51,7 @@ def image2():
 
 @pytest.fixture
 def image2_data(image2):
-    return flask_resize.resizing.image_data(image2, 'PNG')
+    return resizing.image_data(image2, 'PNG')
 
 
 @pytest.fixture
@@ -45,10 +60,29 @@ def filestorage(tmpdir):
 
 
 @pytest.fixture
-def default_filetarget_options(filestorage):
+def redis_cache():
+    if _compat.redis:
+        cache_store = flask_resize.cache.RedisCache(
+            key='flask-resize-redis-test-{}'.format(uuid.uuid4().hex)
+        )
+    else:
+        class FakeRedis:
+            key = None
+        # NOTE: Won't be used as long as @tests.decorators.requires_redis
+        #       is used.
+        cache_store = FakeRedis()
+
+    yield cache_store
+
+    if _compat.redis:
+        cache_store.clear()
+
+
+@pytest.fixture
+def resizetarget_opts(filestorage, image1_name):
     return dict(
         image_store=filestorage,
-        source_image_relative_url='image.png',
+        source_image_relative_url=image1_name,
         dimensions='100x50',
         format='jpeg',
         quality=80,
@@ -59,8 +93,3 @@ def default_filetarget_options(filestorage):
         use_placeholder=False,
         cache_store=flask_resize.cache.NoopCache(),
     )
-
-
-@pytest.fixture
-def filetarget(filestorage, default_filetarget_options):
-    return flask_resize.resizing.ResizeTarget(**default_filetarget_options)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,13 +1,50 @@
 API Documentation
 =================
 
-.. automodule:: flask_resize
+Resizing
+~~~~~~~~
+
+.. automodule:: flask_resize.resizing
+    :members:
+    :special-members:
+    :exclude-members: __weakref__
+
+Storage
+~~~~~~~
+
+.. automodule:: flask_resize.storage
+    :members:
+    :special-members:
+    :exclude-members: __weakref__
+
+Cache
+~~~~~
+
+.. automodule:: flask_resize.cache
+    :members:
+    :special-members:
+    :exclude-members: __weakref__
+
+
+Configuration
+~~~~~~~~~~~~~
+
+.. automodule:: flask_resize.configuration
+    :members:
+    :special-members:
+    :exclude-members: __weakref__
+
+
+Constants
+~~~~~~~~~
+
+.. automodule:: flask_resize.constants
     :members:
     :special-members:
     :exclude-members: __weakref__
 
 Exceptions
-==========
+~~~~~~~~~~
 
 .. automodule:: flask_resize.exc
     :members:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,11 +1,18 @@
 Changelog
 =========
 
-1.0.4 (2017-03-20)
+2.0.0 (2017-03-22)
 ------------------
 
+- **Feature** Added commands for generating images, listing/clearing cache and generated images (see :ref:`cli`)
+- **Feature** Ability to run resizing without a Flask app being involved (see :ref:`standalone-usage`)
+- **Enhancement** Windows is now supported, at least on paper. The test suite runs on a Windows host after each pushed commit, using the excellent CI service AppVeyor. The project still needs some real world usage though. Please report any issues you might find to the Github issues page. (see :ref:`compatibility`)
+- **Enhancement** `dimensions` is now an optional argument. Useful when just converting to a different format for example. (see :ref:`resize-arguments-dimensions`)
+- **Enhancement** Added some basic logging statements for debugging purposes
+- **Enhancement** Pypy and Python 3.6 are now officially supported
 - **Bugfix** Concurrent generation of the same image wasn't handled properly
-- **Enhancement** Add some basic logging statements
+- **Bugfix** There was a logic error when installing `flask-resize[full]`. `redis` and `s3` weren't installed below python3.4.
+- **Breaking** `flask_resize.resize` is no longer available. It's instead accessible when creating the Flask app extension. I.e: `resize = flask_resize.Resize(app)` or `resize = flask_resize.Resize(); resize.init_app(app)`
 
 1.0.3 (2017-03-17)
 ------------------

--- a/docs/command-line.rst
+++ b/docs/command-line.rst
@@ -1,0 +1,22 @@
+.. _cli:
+
+Command line usage
+==================
+
+.. _cli-general:
+
+General
+-------
+
+When installing flask-resize with pip you'll get a command installed along it called ``flask-resize``. See below for the sub commands and what they're used
+for.
+
+.. _cli-usage:
+
+Usage
+~~~~~
+
+.. argparse::
+   :module: flask_resize.bin
+   :func: parser
+   :prog: flask-resize

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,19 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
+import tempfile
+
+
+def add_mock_config_for_flask_resize_bin():
+    _, tempconf_path = tempfile.mkstemp(suffix='.py')
+    with open(tempconf_path, 'w') as fp:
+        fp.write("RESIZE_ROOT = RESIZE_URL = '/'".format(tempconf_path))
+    os.environ['FLASK_RESIZE_CONF'] = tempconf_path
+
+
+add_mock_config_for_flask_resize_bin()
 
 
 package_name = 'flask_resize'
@@ -43,6 +54,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.napoleon',
+    'sphinxarg.ext',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -54,7 +66,7 @@ templates_path = ['_templates']
 source_suffix = '.rst'
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
 master_doc = 'index'
@@ -82,9 +94,9 @@ language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -92,27 +104,27 @@ exclude_patterns = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -128,26 +140,26 @@ todo_include_todos = False
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -157,62 +169,62 @@ html_static_path = ['_static']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'h', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'r', 'sv', 'tr'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Flask-Resizedoc'
@@ -220,46 +232,51 @@ htmlhelp_basename = 'Flask-Resizedoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
 
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # Latex figure (float) alignment
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'Flask-Resize.tex', 'Flask-Resize Documentation',
-   'Jacob Magnusson', 'manual'),
+    (
+        master_doc,
+        'Flask-Resize.tex',
+        'Flask-Resize Documentation',
+        'Jacob Magnusson',
+        'manual'
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
@@ -272,7 +289,7 @@ man_pages = [
 ]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -281,22 +298,28 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'Flask-Resize', 'Flask-Resize Documentation',
-   author, 'Flask-Resize', 'One line description of project.',
-   'Miscellaneous'),
+    (
+        master_doc,
+        'Flask-Resize',
+        'Flask-Resize Documentation',
+        author,
+        'Flask-Resize',
+        'One line description of project.',
+        'Miscellaneous'
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False
 
 
 intersphinx_mapping = {

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -13,7 +13,7 @@ Using direct initialization::
     app.config['RESIZE_URL'] = 'https://mysite.com/'
     app.config['RESIZE_ROOT'] = '/home/user/myapp/images'
 
-    flask_resize.Resize(app)
+    resize = flask_resize.Resize(app)
 
 Using the app factory pattern::
 
@@ -29,17 +29,38 @@ Using the app factory pattern::
         return app
 
     # And later on...
-    app = create_app(RESIZE_URL='https://mysite.com/',
-                     RESIZE_ROOT='/home/user/myapp/images')
+    app = create_app(
+        RESIZE_URL='https://mysite.com/',
+        RESIZE_ROOT='/home/user/myapp/images'
+    )
+
+.. _standalone-usage:
+
+Setting up for standalone usage
+-------------------------------
+
+One doesn't actually need to involve Flask at all to utilize the resizing (perhaps one day we'll break out the actual resizing into its own package). E.g::
+
+    import flask_resize
+
+    config = flask_resize.configuration.Config(
+        url='https://mysite.com/',
+        root='/home/user/myapp/images',
+    )
+
+    resize = flask_resize.make_resizer(config)
+
+.. versionadded:: 2.0.0
+   Standalone mode was introduced
 
 
 Available settings
 ------------------
 
-Required
-~~~~~~~~
+Required for ``file`` storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You need to set at least two configuration options when using the default file-based storage:
+You need to set at least two configuration options when using the default ``file`` storage:
 
 .. code:: python
 
@@ -51,27 +72,33 @@ You need to set at least two configuration options when using the default file-b
     # and with cookies turned off.
     RESIZE_URL = 'http://media.yoursite.com/'
 
+
+Required for ``s3`` storage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 For Amazon S3 storage you only need to do the following if you've already
-configured Amazon Web Services with `aws configure` (or similar). Default
-section configuration can then be extracted using the `boto3` package.
+configured Amazon Web Services with ``aws configure`` (or similar). Default
+section configuration can then be extracted using the included ``botocore``
+package.
 
 .. code:: python
 
     RESIZE_STORAGE_BACKEND = 's3'
-    RESIZE_S3_SECRET_KEY = 'mybucket'
+    RESIZE_S3_BUCKET = 'mybucket'
 
-If you haven't done so then you need to manually specify the following options:
+If you haven't done so then you need to manually specify the following options in addition to above:
 
 .. code:: python
 
-    RESIZE_STORAGE_BACKEND = 's3'
     RESIZE_S3_ACCESS_KEY = 'dq8rJLaMtkHEze4example3C1V'
     RESIZE_S3_SECRET_KEY = 'MC9T4tRqXQexample3d1l7C9sG3M9qes0VEHiNJTG24q4a5'
     RESIZE_S3_REGION = 'eu-central-1'
-    RESIZE_S3_BUCKET = 'mybucket'
 
 .. versionadded:: 1.0.0
    ``RESIZE_S3_ACCESS_KEY``, ``RESIZE_S3_SECRET_KEY`` and ``RESIZE_S3_BUCKET`` were added.
+
+.. versionadded:: 1.0.1
+   ``RESIZE_S3_REGION`` was added.
 
 Optional
 ~~~~~~~~
@@ -96,12 +123,14 @@ There are also some optional settings. They are listed below, with their default
     # return the original image URL.
     RESIZE_NOOP = False
 
-    # Which backend to store files in. Defaults to the file backend. Can be either `file` or `s3`.
+    # Which backend to store files in. Defaults to the `file` backend.
+    # Can be either `file` or `s3`.
     RESIZE_STORAGE_BACKEND = 'file'
 
     # Which cache store to use. Currently only redis is supported (`pip install
     # flask-resize[redis]`), and will be configured automatically if the
-    # package is installed and `RESIZE_CACHE_STORE` hasn't been set explicitly. Otherwise a no-op cache is used.
+    # package is installed and `RESIZE_CACHE_STORE` hasn't been set
+    # explicitly. Otherwise a no-op cache is used.
     RESIZE_CACHE_STORE = 'noop' if redis is None else 'redis'
 
     # Which host to use for redis if it is enabled with `RESIZE_CACHE_STORE`
@@ -116,9 +145,6 @@ There are also some optional settings. They are listed below, with their default
     # Which key to use for redis if it is enabled with `RESIZE_CACHE_STORE`
     RESIZE_REDIS_KEY = 0
 
-    # Can be set if the S3 region has to be specified manually for some reason.
-    RESIZE_S3_REGION = None
-
     # If True then GenerateInProgress exceptions aren't swallowed. Default is
     # to only raise these exceptions when Flask is configured in debug mode.
     RESIZE_RAISE_ON_GENERATE_IN_PROGRESS = app.debug
@@ -128,9 +154,6 @@ There are also some optional settings. They are listed below, with their default
 
 .. versionadded:: 1.0.0
    ``RESIZE_CACHE_STORE``, ``RESIZE_REDIS_HOST``, ``RESIZE_REDIS_PORT``, ``RESIZE_REDIS_DB`` and ``RESIZE_REDIS_KEY`` were added.
-
-.. versionadded:: 1.0.1
-   ``RESIZE_S3_REGION`` was added.
 
 .. versionadded:: 1.0.2
    ``RESIZE_STORAGE_BACKEND`` was added.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,43 +1,7 @@
 Flask-Resize
 ============
 
-Flask extension for automating the resizing of images in your templates. Can convert to/from JPEG/PNG, resize to fit and crop.
-
-.. image:: https://travis-ci.org/jmagnusson/Flask-Resize.svg?branch=master
-   :target: https://travis-ci.org/jmagnusson/Flask-Resize
-   :alt: Travis CI build status (Linux)
-
-.. image:: https://img.shields.io/pypi/v/Flask-Resize.svg
-    :target: https://pypi.python.org/pypi/Flask-Resize/
-    :alt: PyPI version
-
-.. image:: https://img.shields.io/pypi/dm/Flask-Resize.svg
-    :target: https://pypi.python.org/pypi/Flask-Resize/
-    :alt: Downloads from PyPI per month
-
-.. image:: https://img.shields.io/pypi/l/Flask-Resize.svg
-    :target: https://pypi.python.org/pypi/Flask-Resize/
-    :alt: License
-
-.. image:: https://img.shields.io/pypi/wheel/Flask-Resize.svg
-    :target: https://pypi.python.org/pypi/Flask-Resize/
-    :alt: Available as wheel
-
-.. image:: https://img.shields.io/pypi/pyversions/Flask-Resize.svg
-    :target: https://pypi.python.org/pypi/Flask-Resize/
-    :alt: Supported Python versions
-
-.. image:: https://img.shields.io/pypi/status/Flask-Resize.svg
-    :target: https://pypi.python.org/pypi/Flask-Resize/
-    :alt: PyPI status (alpha/beta/stable)
-
-.. image:: https://coveralls.io/repos/jmagnusson/Flask-Resize/badge.svg?branch=master
-    :target: https://coveralls.io/r/jmagnusson/Flask-Resize?branch=master
-    :alt: Code coverage
-
-.. image:: https://landscape.io/github/jmagnusson/Flask-Resize/master/landscape.svg?style=flat
-   :target: https://landscape.io/github/jmagnusson/Flask-Resize/master
-   :alt: Code Health
+Flask extension for automating the resizing of images in your code and templates. Can convert from JPEG|PNG|SVG to JPEG|PNG, resize to fit and crop. File-based and S3-based storage options are available.
 
 
 .. toctree::
@@ -46,7 +10,8 @@ Flask extension for automating the resizing of images in your templates. Can con
    installation
    configuration
    usage
+   command-line
    api
-   todo
    changelog
+   todo
    about

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,13 @@ Installation
 Production version
 ------------------
 
-To install:
+Recommended install with all features (Redis cache + S3 storage + SVG if py3.4+):
+
+.. code:: sh
+
+    pip install flask-resize[full]
+
+Other alternatives:
 
 .. code:: sh
 
@@ -20,8 +26,8 @@ To install:
     # With SVG source file support (only available with py3.4+)
     pip install flask-resize[svg]
 
-    # With all features above
-    pip install flask-resize[full]
+    # Or any combination of above. E.g:
+    pip install flask-resize[s3,redis]
 
 Development version
 -------------------
@@ -30,10 +36,16 @@ Development version
 
     pip install -e git+https://github.com/jmagnusson/flask-resize@master#egg=Flask-Resize
 
+.. _compatibility:
+
 Compatibility
 -------------
 
-Tested with Python 2.7/3.3+ and with latest version of Flask. Will probably not work on Windows as there are some differences in how paths are handled.
+Tested with Python 2.7/3.3/3.4/3.5/3.6/pypy and latest version of Flask.
+
+Should work well on most Linux and MacOS versions.
+
+Windows is supported on paper with the full test suite running smoothly, but  the package needs some real world usage on Windows though. Please report any issues you might find to the Github issues page. Any feedback is welcome! 😊
 
 Running the tests
 -----------------
@@ -66,7 +78,7 @@ Fork the code `on the Github project page <https://github.com/jmagnusson/flask-r
 
     git clone git@github.com:YOUR_USERNAME/Flask-Resize.git
     cd Flask-Resize
-    pip install '.[test,svg,redis,s3]' -r requirements_docs.txt
+    pip install '.[full,test,test_s3]' -r requirements_docs.txt
     git checkout -b my-fix
     # Create your fix and add any tests if deemed necessary.
     # Run the test suite to make sure everything works smooth.

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -1,11 +1,6 @@
 To-do
 =====
 
-Use default S3-settings if not explicitly set up
-------------------------------------------------
-
-Don't require any S3-settings. boto3 automatically reads from `~/.aws/credentials` and `~/.aws/config` if it exists. Perhaps new setting `RESIZE_BACKEND` to configure also.
-
 Automatic fitting of placeholder text
 -------------------------------------
 
@@ -14,8 +9,3 @@ See `issue #7 <https://flask-resize.readthedocs.io/en/latest/changelog.html>`_.
 Support for signals
 -------------------
 Generate images directly instead of when web page is first hit.
-
-Windows
--------
-
-Verify Windows support.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,28 +4,37 @@ Usage
 Usage in Jinja templates
 ------------------------
 
-After having :doc:`installed <installation>` and :doc:`configured <configuration>` Flask-Resize in your app the ``resize`` filter should be available in your jinja templates.
+After having :doc:`installed <installation>` and :doc:`configured <configuration>` Flask-Resize in your app the ``resize`` filter should be available in your code and jinja templates.
 
-Generate an image from the supplied image URL that will fit
+To generate an image from the supplied image URL that will fit
 within an area of 600px width and 400px height::
 
-    {{ original_image_url|resize('600x400') }}
+    resized_url = resize(original_image_url, '600x400')
 
 Resize and crop so that the image will fill the entire area::
 
-    {{ original_image_url|resize('300x300', fill=1) }}
+    resized_url = resize(original_image_url, '300x300', fill=1)
 
 Convert to JPG::
 
-    {{ original_image_url|resize('300x300', format='jpg') }}
+    resized_url = resize(original_image_url, '300x300', format='jpg')
+
+
+The function will also be available in your jinja templates as a filter, where you'll call the resize filter like this::
+
+    <img src="{{ original_image_url|resize('300x300', format='jpg') }}" alt="My kittens">
+
+.. _resize-arguments:
 
 List of arguments
 -----------------
 
+.. _resize-arguments-dimensions:
+
 dimensions
 ~~~~~~~~~~
 
-Required
+Default: Keep original dimensions
 
 Can be either a string or a two item list. The format when using a
 string is any of ``<width>x<height>``, ``<width>`` or ``x<height>``. If

--- a/flask_resize/__init__.py
+++ b/flask_resize/__init__.py
@@ -1,3 +1,3 @@
-from . import cache, exc, resizing, storage  # noqa
-from .resizing import Resize, logger, resize  # noqa
-from .metadata import __version_info__, __version__  # noqa
+from . import cache, configuration, exc, resizing, storage  # noqa
+from .metadata import __version__, __version_info__  # noqa
+from .resizing import Resize, ResizeTarget, logger, make_resizer  # noqa

--- a/flask_resize/_compat.py
+++ b/flask_resize/_compat.py
@@ -1,6 +1,5 @@
 import sys
 
-
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 

--- a/flask_resize/bin.py
+++ b/flask_resize/bin.py
@@ -1,0 +1,135 @@
+import os
+
+import argh
+
+import flask_resize
+
+config = flask_resize.configuration.Config.from_pyfile(
+    os.environ['FLASK_RESIZE_CONF']
+)
+resize = flask_resize.make_resizer(config)
+
+
+@argh.named('images')
+def clear_images():
+    """Delete all generated images from the storage backend"""
+    for filepath in resize.storage_backend.delete_tree(
+        resize.target_directory
+    ):
+        yield filepath
+
+
+@argh.named('cache')
+def list_cache():
+    """List all items found in cache"""
+    for key in resize.cache_store.all():
+        yield key
+
+
+@argh.named('images')
+def list_images():
+    """List all generated images found in storage backend"""
+    for key in resize.storage_backend.list_tree(resize.target_directory):
+        yield key
+
+
+@argh.named('cache')
+def sync_cache():
+    """
+    Syncs paths stored in the cache backend with what's in the storage backend
+
+    Useful when the storage backend destination is shared between multiple
+    environments. One use case is when one has synced generated imagery
+    from production into one's development environment (for example with
+    `aws s3 sync --delete s3://prod-bucket s3://my-dev-bucket`).
+    The cache can then be synced with what's been added/removed from the
+    bucket `my-dev-bucket`.
+    """
+    generated_image_paths = set(resize.storage_backend.list_tree(
+        resize.target_directory
+    ))
+    cached_paths = set(resize.cache_store.all())
+
+    for path in (cached_paths - generated_image_paths):
+        resize.cache_store.remove(path)
+        yield 'Removed {}'.format(path)
+
+    for path in (generated_image_paths - cached_paths):
+        resize.cache_store.add(path)
+        yield 'Added {}'.format(path)
+
+
+@argh.named('cache')
+def clear_cache():
+    """Clear the cache backend from generated images' paths"""
+    resize.cache_store.clear()
+
+
+@argh.named('all')
+def clear_all():
+    """Clear both the cache and all generated images"""
+    clear_cache()
+    for filepath in clear_images():
+        yield filepath
+
+
+@argh.arg('-f', '--format')
+@argh.arg('-F', '--fill')
+def generate(
+    filename,
+    dimensions=None,
+    format=None,
+    quality=80,
+    fill=False,
+    bgcolor=None,
+    upscale=True,
+    progressive=True,
+    placeholder=False
+):
+    """
+    Generate images passed in through stdin. Return URL for resulting image
+
+    Useful to generate images outside of the regular request/response cycle
+    of a web app = happier visitors who don't have to wait until image
+    processing by Flask-Resize completes. Care has to be taken so that the
+    exact same arguments are passed in as what is specified in
+    code/templates - the smallest difference in passed in options will cause
+    flask resize to generate a new image.
+
+    Use GNU Parallel or similar tool to parallelize the generation
+    """
+    return resize(
+        filename,
+        dimensions=dimensions,
+        format=format,
+        quality=quality,
+        fill=fill,
+        bgcolor=bgcolor,
+        upscale=upscale,
+        progressive=progressive,
+        placeholder=placeholder,
+    )
+
+
+parser = argh.ArghParser()
+
+argh.add_commands(parser, [generate])
+
+argh.add_commands(
+    parser,
+    [list_cache, list_images],
+    namespace='list',
+    title="Commands for listing images and cache",
+)
+argh.add_commands(
+    parser,
+    [sync_cache],
+    namespace='sync',
+    title="Commands for syncing data",
+)
+argh.add_commands(
+    parser,
+    [clear_cache, clear_images, clear_all],
+    namespace='clear',
+    title="Commands for clearing/deleting images and cache",
+)

--- a/flask_resize/cache.py
+++ b/flask_resize/cache.py
@@ -1,8 +1,45 @@
+import os
+from contextlib import contextmanager
+
 from . import constants, exc
 from ._compat import redis
 
 
+def make(config):
+    """Generate cache store from supplied config
+
+    Args:
+        config (dict):
+            The config to extract settings from
+
+    Returns:
+        Any[RedisCache, NoopCache]:
+            A :class:`Cache` sub-class, based on the `RESIZE_CACHE_STORE`
+            value.
+
+    Raises:
+        RuntimeError: If another `RESIZE_CACHE_STORE` value was set
+
+    """
+    if config.cache_store == 'redis':
+        kw = dict(
+            host=config.redis_host,
+            port=config.redis_port,
+            db=config.redis_db,
+            key=config.redis_key,
+        )
+        return RedisCache(**kw)
+    elif config.cache_store == 'noop':
+        return NoopCache()
+    else:
+        raise RuntimeError(
+            'Non-supported RESIZE_CACHE_STORE value: "{}"'
+            .format(config.cache_store)
+        )
+
+
 class Cache:
+    """Cache base class"""
 
     def exists(self, unique_key):
         raise NotImplementedError
@@ -16,25 +53,95 @@ class Cache:
     def clear(self):
         raise NotImplementedError
 
+    def all(self):
+        raise NotImplementedError
+
+    def transaction(self, unique_key, ttl=600):
+        raise NotImplementedError
+
 
 class NoopCache(Cache):
+    """
+    No-op cache, just to get the same API regardless of whether cache is
+    used or not.
+    """
 
     def exists(self, unique_key):
+        """
+        Check if key exists in cache
+
+        Args:
+            unique_key (str): Unique key to check for
+
+        Returns:
+            bool: Whether key exist in cache or not
+        """
         return False
 
     def add(self, unique_key):
-        pass
+        """
+        Add key to cache
+
+        Args:
+            unique_key (str): Add this key to the cache
+
+        Returns:
+            bool: Whether key was added or not
+        """
+        return False
 
     def remove(self, unique_key):
-        pass
+        """
+        Remove key from cache
 
-    def clear(self, unique_key):
-        pass
+        Args:
+            unique_key (str): Remove this key from the cache
+
+        Returns:
+            bool: Whether key was removed or not
+        """
+        return False
+
+    def clear(self):
+        """
+        Remove all keys from cache
+
+        Returns:
+            bool: Whether any keys were removed or not
+        """
+        return False
+
+    def all(self):
+        """
+        List all keys in cache
+
+        Returns:
+            List[str]: All the keys in the set, as a list
+        """
+        return []
+
+    @contextmanager
+    def transaction(self, unique_key, ttl=600):
+        """
+        No-op context-manager for transactions. Always yields `True`.
+        """
+        yield True
 
 
 class RedisCache(Cache):
+    """A Redis-based cache that works with a single set-type key
 
-    def __init__(self, host='localhost', port=6379, db=0, key=constants.DEFAULT_REDIS_KEY):
+    Basically just useful for checking whether an expected value in the set
+    already exists (which is exactly what's needed in Flask-Resize)
+    """
+
+    def __init__(
+        self,
+        host='localhost',
+        port=6379,
+        db=0,
+        key=constants.DEFAULT_REDIS_KEY
+    ):
         if redis is None:
             raise exc.RedisImportError(
                 "Redis must be installed for Redis support. "
@@ -47,13 +154,85 @@ class RedisCache(Cache):
         self.redis = redis.StrictRedis(host=host, port=port, db=db)
 
     def exists(self, unique_key):
+        """
+        Check if key exists in cache
+
+        Args:
+            unique_key (str): Unique key to check for
+
+        Returns:
+            bool: Whether key exist in cache or not
+        """
         return self.redis.sismember(self.key, unique_key)
 
     def add(self, unique_key):
-        return self.redis.sadd(self.key, unique_key)
+        """
+        Add key to cache
+
+        Args:
+            unique_key (str): Add this key to the cache
+
+        Returns:
+            bool: Whether key was added or not
+        """
+        return bool(self.redis.sadd(self.key, unique_key))
 
     def remove(self, unique_key):
-        return self.redis.srem(self.key, unique_key)
+        """
+        Remove key from cache
+
+        Args:
+            unique_key (str): Remove this key from the cache
+
+        Returns:
+            bool: Whether key was removed or not
+        """
+        return bool(self.redis.srem(self.key, unique_key))
 
     def clear(self):
-        return self.redis.delete(self.key)
+        """
+        Remove all keys from cache
+
+        Returns:
+            bool: Whether any keys were removed or not
+        """
+        return bool(self.redis.delete(self.key))
+
+    def all(self):
+        """
+        List all keys in cache
+
+        Returns:
+            List[str]: All the keys in the set, as a list
+        """
+        return [v.decode() for v in self.redis.smembers(self.key)]
+
+    @contextmanager
+    def transaction(
+        self,
+        unique_key,
+        ttl=600
+    ):
+        """
+        Context-manager to use when it's important that no one else
+        handles `unique_key` at the same time (for example when
+        saving data to a storage backend).
+
+        Args:
+            unique_key (str):
+                The unique key to ensure atomicity for
+            ttl (int):
+                Time before the transaction is deemed irrelevant and discarded
+                from cache. Is only relevant if the host forcefully restarts.
+        """
+        tkey = '-transaction-'.join([self.key, unique_key])
+
+        if self.redis.set(tkey, str(os.getpid()), nx=True):
+            self.redis.expire(tkey, ttl)
+        else:
+            yield False
+
+        try:
+            yield True
+        finally:
+            self.redis.delete(tkey)

--- a/flask_resize/configuration.py
+++ b/flask_resize/configuration.py
@@ -1,0 +1,63 @@
+from . import constants
+from ._compat import redis
+
+
+class Config:
+    """The main configuration entry point"""
+
+    url = None
+    noop = False
+    root = None
+    raise_on_generate_in_progress = False
+    storage_backend = 'file'
+    target_directory = constants.DEFAULT_TARGET_DIRECTORY
+    hash_method = constants.DEFAULT_NAME_HASHING_METHOD
+    cache_store = 'noop' if redis is None else 'redis'
+    redis_host = 'localhost'
+    redis_port = 6379
+    redis_db = 0
+    redis_key = constants.DEFAULT_REDIS_KEY
+    s3_access_key = None
+    s3_secret_key = None
+    s3_bucket = None
+    s3_region = None
+
+    def __init__(self, **config):
+        for key, val in config.items():
+            setattr(self, key, val)
+
+    @classmethod
+    def from_dict(cls, dct, default_overrides=None):
+        """
+        Turns a dictionary with `RESIZE_` prefix config options into lower-case
+        keys on this object.
+
+        Args:
+            dct (dict):
+                The dictionary to get explicitly set values from
+
+            default_overrides (Any[dict,None]):
+                A dictionary with default overrides, where all declared keys'
+                values will be used as defaults instead of the "app default",
+                in case a setting wasn't explicitly added to config.
+
+        """
+        prefix = 'RESIZE_'
+        default_overrides = default_overrides or {}
+        config = cls()
+
+        def format_key(k):
+            return k.split(prefix, 1)[1].lower()
+
+        for key, val in dict(default_overrides, **dct).items():
+            if key.startswith(prefix):
+                setattr(config, format_key(key), val)
+
+        return config
+
+    @classmethod
+    def from_pyfile(cls, filepath):
+        conf = {}
+        with open(filepath) as config_file:
+            exec(compile(config_file.read(), filepath, 'exec'), conf)
+        return cls.from_dict(conf)

--- a/flask_resize/constants.py
+++ b/flask_resize/constants.py
@@ -1,9 +1,20 @@
 DEFAULT_NAME_HASHING_METHOD = 'sha1'
+"""Default filename hashing method for generated images"""
+
 DEFAULT_TARGET_DIRECTORY = 'resized-images'
+"""Default target directory for generated images"""
+
 DEFAULT_REDIS_KEY = 'flask-resize'
+"""Default key to store redis cache as"""
 
 JPEG = 'JPEG'
+"""JPEG format"""
+
 PNG = 'PNG'
+"""PNG format"""
+
 SVG = 'SVG'
+"""SVG format"""
+
 SUPPORTED_OUTPUT_FILE_FORMATS = (JPEG, PNG)
-PROGRESSIVE_FORMATS = (PNG, SVG)
+"""Image formats that can be generated"""

--- a/flask_resize/metadata.py
+++ b/flask_resize/metadata.py
@@ -1,2 +1,2 @@
-__version_info__ = (1, 0, 4)
+__version_info__ = (2, 0, 0)
 __version__ = '.'.join(map(str, __version_info__))

--- a/flask_resize/storage.py
+++ b/flask_resize/storage.py
@@ -1,10 +1,76 @@
 import os
 
 from . import exc, utils
-from ._compat import PY2, boto3, botocore
+from ._compat import PY2, boto3, botocore, string_types
+
+
+def make(config):
+    """Generate storage backend from supplied config
+
+    Args:
+        config (dict):
+            The config to extract settings from
+
+    Returns:
+        Any[FileStorage, S3Storage]:
+            A :class:`Storage` sub-class, based on the `RESIZE_STORAGE_BACKEND`
+            value.
+
+    Raises:
+        RuntimeError: If another `RESIZE_STORAGE_BACKEND` value was set
+    """
+
+    if config.noop:
+        config.url = '/'
+        return None
+
+    elif config.storage_backend == 's3':
+        if not config.s3_bucket:
+            raise RuntimeError(
+                'You must specify RESIZE_S3_BUCKET when '
+                'RESIZE_STORAGE_BACKEND is set to "s3".'
+            )
+
+        store = S3Storage(
+            access_key=config.s3_access_key,
+            secret_key=config.s3_secret_key,
+            bucket=config.s3_bucket,
+            region_name=config.s3_region,
+        )
+        config.url = store.base_url
+
+    elif config.storage_backend == 'file':
+        if not isinstance(config.url, string_types):
+            raise RuntimeError(
+                'You must specify a valid RESIZE_URL '
+                'when RESIZE_STORAGE_BACKEND is set to "file".'
+            )
+
+        if not isinstance(config.root, string_types):
+            raise RuntimeError(
+                'You must specify a valid RESIZE_ROOT '
+                'when RESIZE_STORAGE_BACKEND is set to "file".'
+            )
+        if not os.path.isdir(config.root):
+            raise RuntimeError(
+                'Your RESIZE_ROOT does not exist or is a regular file.'
+            )
+        if not config.root.endswith(os.sep):
+            config.root = config.root + os.sep
+
+        store = FileStorage(base_path=config.root)
+
+    else:
+        raise RuntimeError(
+            'Non-supported RESIZE_STORAGE_BACKEND value: "{}"'
+            .format(config.storage_backend)
+        )
+
+    return store
 
 
 class Storage:
+    """Storage backend base class"""
 
     def __init__(self, *args, **kwargs):
         pass
@@ -15,25 +81,60 @@ class Storage:
     def save(self, relative_path, bdata):
         raise NotImplementedError
 
+    def exists(self, relative_path):
+        raise NotImplementedError
+
     def delete(self, relative_path):
         raise NotImplementedError
 
-    def exists(self, relative_path):
+    def list_tree(self, subdir):
+        raise NotImplementedError
+
+    def delete_tree(self, subdir):
         raise NotImplementedError
 
 
 class FileStorage(Storage):
+    """Local file based storage
+
+    Note that to follow the same convention as for `S3Storage`, all
+    methods' passed in and extracted paths must use forward slash as
+    path separator. the path separator. The only exception is the `base_path`
+    passed in to the constructor.
+
+    Args:
+        base_path (str): The directory where files will be read from and written to. Expected to use the local OS's path separator.
+
+    """
 
     def __init__(self, base_path):
         self.base_path = base_path
 
-    def _get_full_path(self, relative_path):
-        return os.path.join(self.base_path, relative_path)
+    def _get_full_path(self, key):
+        """
+        Replaces key with OS specific path separator and joins with `base_path`
 
-    def get(self, relative_path):
-        if not relative_path:
+        Args:
+            key (str): The key / relative file path to make whole
+
+        Returns:
+            str: The full path
+        """
+        key = key.replace('/', os.sep)
+        return os.path.join(self.base_path, key)
+
+    def get(self, key):
+        """Get binary file data for specified key
+
+        Args:
+            key (str): The key / relative file path to get data for
+
+        Returns:
+            bytes: The file's binary data
+        """
+        if not key:
             raise exc.ImageNotFoundError()
-        path = self._get_full_path(relative_path)
+        path = self._get_full_path(key)
         try:
             with open(path, 'rb') as fp:
                 return fp.read()
@@ -43,35 +144,111 @@ class FileStorage(Storage):
             else:
                 raise
 
-    def save(self, relative_path, bdata):
-        full_path = self._get_full_path(relative_path)
-        utils.mkdir_p(full_path.rpartition('/')[0])
+    def save(self, key, bdata):
+        """Store binary file data at specified key
+
+        Args:
+            key (str): The key / relative file path to store data at
+            bdata (bytes): The file data
+        """
+        full_path = self._get_full_path(key)
+        utils.mkdir_p(os.path.split(full_path)[0])
 
         # Python 2 doesn't natively support `xb` mode as used below. Have to
         # manually check for the file's existence.
-        if PY2 and self.exists(relative_path):
+        if PY2 and self.exists(key):
             raise exc.FileExistsError(17, 'File exists')
         with open(full_path, 'wb' if PY2 else 'xb') as fp:
             fp.write(bdata)
 
-    def delete(self, relative_path):
-        os.remove(self._get_full_path(relative_path))
+    def exists(self, key):
+        """Check if the key exists in the backend
 
-    def exists(self, relative_path):
-        if not relative_path:
+        Args:
+            key (str): The key / relative file path to check
+
+        Returns:
+            bool: Whether the file exists or not
+        """
+        if not key:
             return False
-        full_path = self._get_full_path(relative_path)
+        full_path = self._get_full_path(key)
         return os.path.exists(full_path)
+
+    def delete(self, key):
+        """Delete file at specified key
+
+        Args:
+            key (str): The key / relative file path to delete
+        """
+        os.remove(self._get_full_path(key))
+
+    def list_tree(self, subdir):
+        """
+        Recursively yields all regular files' names in a sub-directory of the
+        storage backend.
+
+        Keys/filenames are returned `self.base_path`-relative, and uses
+        forward slash as a path separator, regardless of OS.
+
+        Args:
+            subdir (str):
+                The subdirectory to list paths for
+
+        Returns:
+            Generator[str, str, None]:
+                Yields subdirectory's filenames
+        """
+        assert subdir, 'Subdir must be specified'
+        base_path = self.base_path
+        if not base_path.endswith(os.sep):
+            base_path += os.sep
+        tree_base = os.path.join(base_path, subdir)
+        for root, dirs, filenames in os.walk(tree_base, topdown=False):
+            for filename in filenames:
+                root_relative_path = root[len(base_path):].replace(os.sep, '/')
+                relative_path = '/'.join([root_relative_path, filename])
+                yield relative_path
+
+    def delete_tree(self, subdir):
+        """
+        Recursively deletes all regular files in specified sub-directory
+
+        Args:
+            subdir (str):
+                The subdirectory to delete files in
+
+        Returns:
+            Generator[str, str, None]:
+                Yields deleted subdirectory's filenames
+        """
+        for relative_path in self.list_tree(subdir):
+            full_path = self._get_full_path(relative_path)
+            os.remove(full_path)
+            yield relative_path
 
 
 class S3Storage(Storage):
+    """
+    Amazon Web Services S3 based storage
+
+    Args:
+        bucket (str): Bucket name
+        access_key (Any[str, None]): The access key. Defaults to reading from the local AWS config.
+        secret_key (Any[str, None]): The secret access key. Defaults to reading from the local AWS config.
+        region_name (Any[str, None]): The name of the bucket's region. Defaults to reading from the local AWS config.
+        file_acl (str):
+            The ACL to set on uploaded images. Defaults to "public-read"
+
+    """
 
     def __init__(
         self,
         bucket,
         access_key=None,
         secret_key=None,
-        region_name=None
+        region_name=None,
+        file_acl='public-read'
     ):
         if boto3 is None:
             raise exc.Boto3ImportError(
@@ -88,17 +265,22 @@ class S3Storage(Storage):
             secret_key or getattr(default_credentials, 'secret_key', None)
         self.region_name = \
             region_name or default_session.get_config_variable('region')
+        self.file_acl = 'public-read'
         self.s3 = boto3.resource(
             's3',
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
             region_name=region_name,
         )
-        self.bucket = self.s3.Bucket(self.bucket_name)
         self._verify_configuration()
 
     @property
     def base_url(self):
+        """The base URL for the storage's bucket
+
+        Returns:
+            str: The URL
+        """
         return '/'.join([self.s3.meta.client._endpoint.host, self.bucket_name])
 
     def _verify_configuration(self):
@@ -116,6 +298,14 @@ class S3Storage(Storage):
             )
 
     def get(self, relative_path):
+        """Get binary file data for specified key
+
+        Args:
+            key (str): The key to get data for
+
+        Returns:
+            bytes: The file's binary data
+        """
         if not relative_path:
             raise exc.ImageNotFoundError()
         obj = self.s3.Object(self.bucket_name, relative_path)
@@ -131,20 +321,35 @@ class S3Storage(Storage):
         return resp['Body'].read()
 
     def save(self, relative_path, bdata):
-        self.bucket.put_object(
+        """Store binary file data at specified key
+
+        Args:
+            key (str): The key to store data at
+            bdata (bytes): The file data
+        """
+        self.s3.meta.client.put_object(
+            Bucket=self.bucket_name,
             Key=relative_path,
             Body=bdata,
-            ACL='public-read'
+            ACL=self.file_acl
         )
 
-    def delete(self, relative_path):
-        return self.s3.Object(self.bucket_name, relative_path).delete()
-
     def exists(self, relative_path):
+        """Check if the key exists in the backend
+
+        Args:
+            key (str): The key to check
+
+        Returns:
+            bool: Whether the key exists or not
+        """
         if not relative_path:
             return False
         try:
-            self.s3.Object(self.bucket_name, relative_path).load()
+            self.s3.meta.client.head_object(
+                Bucket=self.bucket_name,
+                Key=relative_path
+            )
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == '404':
                 return False
@@ -152,3 +357,65 @@ class S3Storage(Storage):
                 raise
         else:
             return True
+
+    def delete(self, relative_path):
+        """Delete file at specified key
+
+        Args:
+            key (str): The key to delete
+        """
+        return self.s3.meta.client.delete_object(
+            Bucket=self.bucket_name,
+            Key=relative_path,
+        )
+
+    def list_tree(self, subdir):
+        """
+        Recursively yields all keys in a sub-directory of the storage backend
+
+        Args:
+            subdir (str):
+                The subdirectory to list keys for
+
+        Returns:
+            Generator[str, str, None]:
+                Yields subdirectory's keys
+        """
+        assert subdir, 'Subdir must be specified'
+        if not subdir.endswith('/'):
+            subdir += '/'
+
+        kw = dict(Bucket=self.bucket_name, Prefix=subdir)
+
+        while True:
+            resp = self.s3.meta.client.list_objects_v2(**kw)
+            for obj in resp.get('Contents', ()):
+                yield obj['Key']
+            if resp.get('NextContinuationToken'):
+                kw['ContinuationToken'] = resp['NextContinuationToken']
+            else:
+                break
+
+    def delete_tree(self, subdir):
+        """
+        Recursively deletes all keys in specified sub-directory (prefix)
+
+        Args:
+            subdir (str):
+                The subdirectory to delete keys in
+
+        Returns:
+            Generator[str, str, None]:
+                Yields subdirectory's deleted keys
+        """
+        assert subdir, 'Subdir must be specified'
+
+        for keys in utils.chunked(self.list_tree(subdir), 1000):
+            self.s3.meta.client.delete_objects(
+                Bucket=self.bucket_name,
+                Delete={
+                    'Objects': [{'Key': key} for key in keys]
+                }
+            )
+            for key in keys:
+                yield key

--- a/flask_resize/utils.py
+++ b/flask_resize/utils.py
@@ -1,4 +1,5 @@
 import errno
+import itertools
 import os
 
 from . import constants, exc
@@ -106,7 +107,7 @@ def parse_format(image_path, format=None):
             Format of supplied image
     """
     if not format:
-        _, _, format = image_path.rpartition('.')
+        format = os.path.splitext(image_path)[1][1:]
     format = format.upper()
     if format in ('JPEG', 'JPG'):
         format = constants.JPEG
@@ -118,3 +119,9 @@ def parse_format(image_path, format=None):
             "file formats at the moment."
         )
     return format
+
+
+def chunked(iterable, size):
+    """Split iterable `iter` into one or more `size` sized tuples"""
+    it = iter(iterable)
+    return iter(lambda: tuple(itertools.islice(it, size)), ())

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,4 @@
+sphinx-argparse>=0.1.17
 sphinx-autobuild>=0.6.0
 sphinx-rtd-theme>=0.2.4
 sphinx>=1.5.3

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,11 @@
 Flask-Resize
 ------------
 
-Flask extension for resizing images in code and templates.
+Flask extension for automating the resizing of images in your code and
+templates. Can convert from JPEG|PNG|SVG to JPEG|PNG, resize to fit and crop.
+File-based and S3-based storage options are available.
 
-See https://github.com/jmagnusson/Flask-Resize for usage.
+See https://flask-resize.readthedocs.io/ for documentation.
 
 """
 from __future__ import print_function
@@ -38,9 +40,10 @@ setup(
         ],
     },
     install_requires=[
-        'Pillow',
-        'pilkit',
+        'argh',
         'Flask',
+        'pilkit',
+        'Pillow',
     ],
     extras_require={
         'svg': ['cairosvg'],
@@ -48,7 +51,7 @@ setup(
         's3': ['boto3'],
         'full': (
             ['redis', 's3'] +
-            ['cairosvg'] if sys.version_info >= (3, 4) else []
+            (['cairosvg'] if sys.version_info >= (3, 4) else [])
         ),
         'test': [
             'click>=6.7',
@@ -58,7 +61,9 @@ setup(
         'test_s3': ['moto>=0.4.31'],
     },
     entry_points={
-        'console_scripts': {},
+        'console_scripts': {
+            'flask-resize = flask_resize.bin:parser.dispatch',
+        },
     },
     author='Jacob Magnusson',
     author_email='m@jacobian.se',
@@ -78,5 +83,8 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,5 @@
 import flask
+
 from flask_resize import Resize
 
 

--- a/tests/decorators.py
+++ b/tests/decorators.py
@@ -1,0 +1,28 @@
+import pytest
+
+from flask_resize import _compat
+
+slow = pytest.mark.skipif(
+    pytest.config.getoption("--skip-slow"),
+    reason="--skip-slow passed in, skipping..."
+)
+
+requires_redis = pytest.mark.skipif(
+    _compat.redis is None,
+    reason='Redis is not installed'
+)
+
+requires_boto3 = pytest.mark.skipif(
+    _compat.boto3 is None,
+    reason='`boto3` has to be installed to run this test'
+)
+
+requires_cairosvg = pytest.mark.skipif(
+    _compat.cairosvg is None,
+    reason="CairoSVG 2.0+ is not installed. Only supported in Python 3.4+"
+)
+
+requires_no_cairosvg = pytest.mark.skipif(
+    _compat.cairosvg is not None,
+    reason="Should only test CairoSVG import error when it isn't installed"
+)

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -1,0 +1,119 @@
+import os
+import subprocess
+
+import pytest
+
+import flask_resize
+
+from .decorators import requires_redis, slow
+
+
+@pytest.fixture
+def env(tmpdir, redis_cache):
+    basedir = tmpdir
+    conffile = tmpdir.join('flask-resize-conf.py')
+    conffile.write(
+        """
+RESIZE_URL = 'https://example.com'
+RESIZE_ROOT = '{root}'
+RESIZE_REDIS_KEY = '{cache_key}'
+        """
+        .format(
+            root=str(basedir).replace('\\', '\\\\'),
+            cache_key=redis_cache.key,
+        ).strip()
+    )
+    env = os.environ.copy()
+    # env = dict(PATH=os.environ['PATH'])
+    env.update(FLASK_RESIZE_CONF=str(conffile))
+    return env
+
+
+def run(env, *args):
+    return subprocess.check_output(args, env=env).decode().splitlines()
+
+
+@slow
+def test_bin_usage(env):
+    assert 'usage: flask-resize' in run(env, 'flask-resize', '--help')[0]
+
+
+@slow
+def test_bin_list_images_empty(env):
+    assert run(env, 'flask-resize', 'list', 'images') == []
+
+
+@slow
+def test_bin_list_has_images(
+    env,
+    resizetarget_opts,
+    image1_name,
+    image1_data,
+    image1_key
+):
+    resize_target = flask_resize.ResizeTarget(**resizetarget_opts)
+
+    resize_target.image_store.save(image1_name, image1_data)
+    resize_target.generate()
+    assert run(env, 'flask-resize', 'list', 'images') == [image1_key]
+
+
+@requires_redis
+@slow
+def test_bin_list_cache_empty(env, redis_cache):
+    assert run(env, 'flask-resize', 'list', 'cache') == []
+
+
+@requires_redis
+@slow
+def test_bin_list_has_cache(env, redis_cache):
+    redis_cache.add('hello')
+    redis_cache.add('buh-bye')
+    assert set(run(env, 'flask-resize', 'list', 'cache')) == \
+        {'hello', 'buh-bye'}
+
+
+@slow
+def test_bin_clear_images(
+    env,
+    resizetarget_opts,
+    image1_name,
+    image1_data
+):
+    resize_target = flask_resize.ResizeTarget(**resizetarget_opts)
+
+    resize_target.image_store.save(image1_name, image1_data)
+    resize_target.generate()
+    run(env, 'flask-resize', 'clear', 'images')
+    assert run(env, 'flask-resize', 'list', 'images') == []
+
+
+@requires_redis
+@slow
+def test_bin_clear_cache(env, redis_cache):
+    redis_cache.add('foo bar')
+    assert run(env, 'flask-resize', 'clear', 'cache') == []
+
+
+@requires_redis
+@slow
+def test_bin_sync_cache(
+    env,
+    resizetarget_opts,
+    image1_name,
+    image1_data,
+    image1_key,
+    redis_cache
+):
+    resize_target = flask_resize.ResizeTarget(**resizetarget_opts)
+
+    resize_target.image_store.save(image1_name, image1_data)
+    resize_target.generate()
+
+    redis_cache.clear()
+
+    assert run(env, 'flask-resize', 'list', 'cache') == []
+
+    run(env, 'flask-resize', 'sync', 'cache')
+
+    assert run(env, 'flask-resize', 'list', 'images') == [image1_key]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,31 +1,26 @@
 import pytest
 
-from flask_resize import _compat, exc, resizing
-from flask_resize.cache import RedisCache
+from flask_resize import exc, resizing
+
+from .decorators import requires_redis
 
 
-@pytest.mark.skipif(
-    _compat.redis is None,
-    reason="Redis not installed"
-)
-def test_redis_cache(default_filetarget_options, image1_data):
+@requires_redis
+def test_redis_cache(redis_cache, resizetarget_opts, image1_data, image1_name):
 
-    options = default_filetarget_options.copy()
-    cache_store = RedisCache(key='flask-resize-redis-test')
-    cache_store.clear()
-    options.update(cache_store=cache_store)
-    resize_target = resizing.ResizeTarget(**options)
+    resizetarget_opts.update(cache_store=redis_cache)
+    resize_target = resizing.ResizeTarget(**resizetarget_opts)
 
-    assert not cache_store.exists(resize_target.unique_key)
+    assert not redis_cache.exists(resize_target.unique_key)
 
     with pytest.raises(exc.CacheMiss):
         resize_target.get_cached_path()
 
-    resize_target.image_store.save('image.png', image1_data)
+    resize_target.image_store.save(image1_name, image1_data)
     resize_target.generate()
 
-    assert cache_store.exists(resize_target.unique_key) is True
+    assert redis_cache.exists(resize_target.unique_key) is True
     assert resize_target.get_cached_path() == resize_target.unique_key
 
-    cache_store.remove(resize_target.unique_key)
-    assert cache_store.exists(resize_target.unique_key) is False
+    redis_cache.remove(resize_target.unique_key)
+    assert redis_cache.exists(resize_target.unique_key) is False

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,27 +1,25 @@
-import pytest
-
 from multiprocessing.dummy import Pool
 
+import pytest
+
 import flask_resize
-from flask_resize import _compat
+
+from .decorators import requires_redis
 
 
-@pytest.mark.skipif(
-    _compat.redis is None,
-    reason="Redis not installed"
-)
-def test_generate_in_progress(default_filetarget_options, image1_data):
-    cache_store = flask_resize.cache.RedisCache(
-        key='flask-resize-generate-in-progress-test'
-    )
-    cache_store.clear()
-    options = default_filetarget_options.copy()
-    options.update(cache_store=cache_store)
+@requires_redis
+def test_generate_in_progress(
+    redis_cache,
+    resizetarget_opts,
+    image1_data,
+    image1_name
+):
+    resizetarget_opts.update(cache_store=redis_cache)
 
-    resize_target = flask_resize.resizing.ResizeTarget(**options)
+    resize_target = flask_resize.resizing.ResizeTarget(**resizetarget_opts)
 
     # Save original file
-    resize_target.image_store.save('image.png', image1_data)
+    resize_target.image_store.save(image1_name, image1_data)
 
     def run(x):
         resize_target.generate()

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,7 +1,7 @@
+import os
+
 import flask
 import pytest
-
-from flask_resize import resize
 
 from .base import create_resizeapp
 
@@ -12,15 +12,15 @@ def test_resize_settings():
     with pytest.raises(RuntimeError):
         create_resizeapp(RESIZE_URL='http://test.dev')
     with pytest.raises(RuntimeError):
-        create_resizeapp(RESIZE_ROOT='/')
+        create_resizeapp(RESIZE_ROOT=os.sep)
 
     working_app = create_resizeapp(RESIZE_URL='http://test.dev',
-                                   RESIZE_ROOT='/')
+                                   RESIZE_ROOT=os.sep)
     assert isinstance(working_app, flask.Flask)
 
 
 def test_resize_noop():
     app = create_resizeapp(RESIZE_NOOP=True)
     with app.test_request_context():
-        generated_image_path = resize('xyz.png', 'WxH')
+        generated_image_path = app.resize('xyz.png', 'WxH')
     assert generated_image_path == 'xyz.png'

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,35 +6,39 @@ import flask_resize
 from flask_resize._compat import boto3
 
 from ._mocking import mock_s3
+from .decorators import requires_boto3
 
 
 def test_file_storage(filestorage, tmpdir):
+    basepath = tmpdir.mkdir('subdir')
+    tmpdir.mkdir('subdir/subsubdir')
 
-    filepath1 = tmpdir.join('file1.txt')
+    filepath1 = basepath.join('file1.txt')
     filepath1.write('content')
-    data = filestorage.get(str(filepath1))
-    assert data == b'content'
-
-    filepath2 = tmpdir.join('file2.txt')
-    filestorage.save(str(filepath2), b'content')
-    data = filestorage.get(str(filepath2))
+    data = filestorage.get('subdir/file1.txt')
     assert data == b'content'
 
     with pytest.raises(flask_resize.exc.FileExistsError):
-        filestorage.save(str(filepath2), b'')
+        filestorage.save('subdir/file1.txt', b'')
 
-    filestorage.delete(str(filepath2))
+    filestorage.delete('subdir/file1.txt')
 
     with pytest.raises(OSError) as excinfo:
-        filestorage.delete(str(filepath2))
+        filestorage.delete('subdir/file1.txt')
     assert excinfo.value.errno == 2
+
+    filestorage.save('subdir/file2.txt', b'content2')
+    filestorage.save('subdir/subsubdir/file3.txt', b'content3')
+
+    expected_relpaths = set(['subdir/file2.txt', 'subdir/subsubdir/file3.txt'])
+
+    assert set(filestorage.list_tree('subdir')) == expected_relpaths
+    assert set(filestorage.delete_tree('subdir')) == expected_relpaths
+    assert list(filestorage.delete_tree('subdir')) == []
 
 
 @mock_s3
-@pytest.mark.skipif(
-    boto3 is None,
-    reason='`boto3` has to be installed to run this test'
-)
+@requires_boto3
 def test_s3_storage():
     real_access_key = os.environ.get('RESIZE_S3_ACCESS_KEY')
     real_secret_key = os.environ.get('RESIZE_S3_SECRET_KEY')
@@ -57,15 +61,24 @@ def test_s3_storage():
     )
 
     # In case it already exists
-    s3_storage.delete('file1.txt')
+    s3_storage.delete('subdir/file1.txt')
 
-    assert s3_storage.exists('file1.txt') is False
+    assert s3_storage.exists('subdir/file1.txt') is False
 
-    s3_storage.save('file1.txt', b'content')
-    data = s3_storage.get('file1.txt')
+    s3_storage.save('subdir/file1.txt', b'content')
+    data = s3_storage.get('subdir/file1.txt')
 
-    assert s3_storage.exists('file1.txt') is True
+    assert s3_storage.exists('subdir/file1.txt') is True
     assert data == b'content'
 
     # Cleanup
-    s3_storage.delete('file1.txt')
+    s3_storage.delete('subdir/file1.txt')
+
+    s3_storage.save('subdir/file2.txt', b'content2')
+    s3_storage.save('subdir/subsubdir/file3.txt', b'content3')
+
+    expected_relpaths = set(['subdir/file2.txt', 'subdir/subsubdir/file3.txt'])
+
+    assert set(s3_storage.list_tree('subdir')) == expected_relpaths
+    assert set(s3_storage.delete_tree('subdir')) == expected_relpaths
+    assert list(s3_storage.delete_tree('subdir')) == []

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,11 @@
 
 [tox]
 envlist =
-    py{27,33,34,35}-release,
-    py{27,33,34,35}-full,
-    py{27,33,34,35}-redis,
-    py{27,33,34,35}-s3,
-    py{34,35}-svg,
+    py{27,33,34,35,36,py}-release,
+    py{27,33,34,35,36,py}-full,
+    py{27,33,34,35,36,py}-redis,
+    py{27,33,34,35,36,py}-s3,
+    py{34,35,36}-svg,
     lint
 
 [testenv]
@@ -26,9 +26,12 @@ passenv = RESIZE_*
 [testenv:lint]
 commands =
     flake8 flask_resize tests
+    isort --recursive --diff flask_resize tests
+    isort --recursive --check-only flask_resize tests
 deps =
     .[test]
     flake8
+    isort
 
 [flake8]
 ignore = E501


### PR DESCRIPTION
With the following changes:

- **Feature** Added commands for generating images, listing/clearing cache and generated images
- **Feature** Ability to run resizing without a Flask app being involved
- **Enhancement** Windows is now supported, at least on paper. The test suite runs on a Windows host after each pushed commit, using the excellent CI service AppVeyor. The project still needs some real world usage though. Please report any issues you might find to the Github issues page.
- **Enhancement** `dimensions` is now an optional argument. Useful when just converting to a different format for example.
- **Enhancement** Added some basic logging statements for debugging purposes
- **Enhancement** Pypy and Python 3.6 are now officially supported
- **Bugfix** Concurrent generation of the same image wasn't handled properly
- **Bugfix** There was a logic error when installing `flask-resize[full]`. `redis` and `s3` weren't installed below python3.4.
- **Breaking** `flask_resize.resize` is no longer available. It's instead accessible when creating the Flask app extension. I.e: `resize = flask_resize.Resize(app)` or `resize = flask_resize.Resize(); resize.init_app(app)`